### PR TITLE
Remove resource not found warning

### DIFF
--- a/operator/resourcehandle.py
+++ b/operator/resourcehandle.py
@@ -848,11 +848,6 @@ class ResourceHandle(KopfObject):
                 api_version=api_version, kind=kind, name=name, namespace=namespace,
             )
             resource_states.append(resource)
-            if not resource:
-                if namespace:
-                    logger.warning(f"Mangaged resource {api_version} {kind} {name} in {namespace} not found.")
-                else:
-                    logger.warning(f"Mangaged resource {api_version} {kind} {name} not found.")
         return resource_states
 
     async def handle_delete(self, logger: kopf.ObjectLogger) -> None:


### PR DESCRIPTION
- Should not warn on resource not found as there are many normal cases where the resource will not exist.