### PR TITLE
Update GitHub Actions workflow and dependencies

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,60 +3,77 @@ name: publish
 on:
   push:
     branches-ignore:
-    - '*'
+      - '*'
     tags:
-    - 'v[0-9]*'
+      - 'v[0-9]*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to be published (e.g., v1.12.0, v1.12.0-1)"
+        required: true
+        type: string
+        default: "latest"
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v2
+      - name: Checkout source
+        uses: actions/checkout@v4
 
-    - name: Get image tags
-      id: image_tags
-      run: |
-        # Version is a semantic version tag or semantic version with release number
-        # GITHUB_REF will be of the form "refs/tags/v0.1.2" or "refs/tags/v0.1.2-1"
-        # To determine RELEASE, strip off the leading "refs/tags/"
-        RELEASE=${GITHUB_REF#refs/tags/}
-        # To determine VERSION, strip off any release number suffix
-        VERSION=${RELEASE/-*/}
+      - name: Get image tags
+        id: image_tags
+        run: |
+          if [[ -n "${{ github.event.inputs.version }}" ]]; then
+            VERSION=${{ github.event.inputs.version }}
+            RELEASE=${{ github.event.inputs.version }}
+            IMAGE_TAGS=(
+              "${{ vars.IMAGE_REGISTRY }}/${{ vars.IMAGE_REPOSITORY }}/${{ vars.IMAGE_NAME }}:${VERSION}"
+            )
+          else
+            VERSION=${GITHUB_REF#refs/tags/}
+            IMAGE_TAGS=(
+              "${{ vars.IMAGE_REGISTRY }}/${{ vars.IMAGE_REPOSITORY }}/${{ vars.IMAGE_NAME }}:latest"
+              "${{ vars.IMAGE_REGISTRY }}/${{ vars.IMAGE_REPOSITORY }}/${{ vars.IMAGE_NAME }}:${VERSION%.*}"
+              "${{ vars.IMAGE_REGISTRY }}/${{ vars.IMAGE_REPOSITORY }}/${{ vars.IMAGE_NAME }}:${VERSION}"
+            )
+          fi
+          ( IFS=$','; echo "IMAGE_TAGS=${IMAGE_TAGS[*]}" >> $GITHUB_OUTPUT )
 
-        # Only build image if version tag without release number
-        # Releases indicate a change in the repository that should not trigger a new build.
-        if [[ "${VERSION}" == "${RELEASE}" ]]; then
-          # Publish to latest, minor, and patch tags
-          # Ex: latest,v1.2,v1.2.3
-          echo "IMAGE_TAGS=latest ${VERSION%.*} ${VERSION}" >> $GITHUB_OUTPUT
-        fi
+      - name: Validate Helm Chart version
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          VERSION="${{ steps.image_tags.outputs.VERSION }}"
+          HELM_CHART_VERSION=$(sed -nr 's/^appVersion: (.*)/\1/p' helm/Chart.yaml)
+          if [[ "v${HELM_CHART_VERSION}" != "${VERSION}" ]]; then
+            echo "Helm chart version does not match tag!"
+            exit 1
+          fi
 
-        # Read version from helm/Chart.yaml
-        HELM_CHART_VERSION=$(sed -nr 's/^appVersion: (.*)/\1/p' helm/Chart.yaml)
-        if [[ "v${HELM_CHART_VERSION}" != "${VERSION}" ]]; then
-          echo "Helm chart version does not match tag!"
-          exit 1
-        fi
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        if: steps.image_tags.outputs.IMAGE_TAGS
+        with:
+          version: latest
 
-    - name: Buildah Action
-      id: buildah-build
-      if: steps.image_tags.outputs.IMAGE_TAGS
-      uses: redhat-actions/buildah-build@v2
-      with:
-        image: ${{ vars.IMAGE_NAME }}
-        tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}
-        containerfiles: Containerfile
+      - name: Login to Image Registry
+        uses: docker/login-action@v3
+        if: steps.image_tags.outputs.IMAGE_TAGS
+        with:
+          registry: ${{ vars.IMAGE_REGISTRY }}/${{ vars.IMAGE_REPOSITORY }}
+          username: ${{ secrets.IMAGE_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
 
-    - name: Push image to registry
-      id: push-to-registry
-      if: steps.image_tags.outputs.IMAGE_TAGS
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ steps.buildah-build.outputs.image }}
-        tags: ${{ steps.buildah-build.outputs.tags }}
-        registry: ${{ vars.IMAGE_REGISTRY }}/${{ vars.IMAGE_REPOSITORY }}
-        username: ${{ secrets.IMAGE_REGISTRY_USERNAME }}
-        password: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
+      - name: Build and push
+        if: steps.image_tags.outputs.IMAGE_TAGS
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Containerfile
+          push: true
+          tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}
+          cache-from: type=gha,scope=${{ vars.IMAGE_NAME }}
+          cache-to: type=gha,mode=max,scope=${{ vars.IMAGE_NAME }}
 
   publish-helm-charts:
     needs: publish
@@ -65,20 +82,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Checkout gh-pages
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: gh-pages
         path: gh-pages
 
     - name: Configure Helm
-      uses: azure/setup-helm@v1
+      uses: azure/setup-helm@v4
       with:
         version: latest
+
+    - name: Lint Helm Chart
+      run: helm lint helm/
 
     - name: Package Helm Chart
       run: |
@@ -93,5 +113,6 @@ jobs:
         git config user.name "$GITHUB_ACTOR"
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
         git add .
+        git diff --cached --quiet && echo 'No changes to commit' && exit 0
         git commit -m "Updating Helm Chart Repository"
         git push

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,19 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
-    #- name: Static tests
-    #  run: |
-
-    - name: Buildah Action
-      id: buildah-build
-      if: steps.image_tags.outputs.IMAGE_TAGS
-      uses: redhat-actions/buildah-build@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
       with:
-        image: ${{ vars.IMAGE_NAME }}
-        tags: latest
-        containerfiles: Containerfile
+        version: latest
 
-    #- name: Test image
-    #  run: |
+    - name: Build image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Containerfile
+        push: false
+        tags: ${{ vars.IMAGE_NAME }}:latest

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -23,3 +23,5 @@ jobs:
         file: Containerfile
         push: false
         tags: ${{ vars.IMAGE_NAME }}:latest
+        cache-from: type=gha,scope=${{ vars.IMAGE_NAME }}
+        cache-to: type=gha,mode=max,scope=${{ vars.IMAGE_NAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 .odo/
 .odo/env
 .odo/odo-file-index.json
+.venv/

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-cop/python-kopf-s2i:v1.37
+FROM quay.io/rhpds/python-kopf-s2i:v1.38
 
 USER root
 

--- a/operator/resourceprovider.py
+++ b/operator/resourceprovider.py
@@ -752,13 +752,7 @@ class ResourceProvider:
         })
 
         if resource_claim:
-            # TODO: The following annotations are kept for backward
-            # compatibility and will be removed in the future.
             resource_definition['metadata']['annotations'].update({
-                f"{Poolboy.operator_domain}/resource-claim-name": resource_claim.name,
-                f"{Poolboy.operator_domain}/resource-claim-namespace": resource_claim.namespace,
-            })
-            resource_definition['metadata'].setdefault('labels', {}).update({
                 f"{Poolboy.operator_domain}/resource-claim-name": resource_claim.name,
                 f"{Poolboy.operator_domain}/resource-claim-namespace": resource_claim.namespace,
             })

--- a/operator/resourceprovider.py
+++ b/operator/resourceprovider.py
@@ -1,20 +1,18 @@
 import asyncio
+import re
+from copy import deepcopy
+from datetime import timedelta
+from typing import List, Mapping, Optional, TypeVar
+
 import jinja2
 import jsonpointer
 import kopf
-import pytimeparse
-import re
-
-from copy import deepcopy
-from datetime import timedelta
-from openapi_schema_validator import OAS30Validator
-from openapi_schema_util import defaults_from_schema
-from typing import List, Mapping, Optional, TypeVar
-
 import poolboy_k8s
-
+import pytimeparse
 from deep_merge import deep_merge
 from jsonpatch_from_diff import jsonpatch_from_diff
+from openapi_schema_util import defaults_from_schema
+from openapi_schema_validator import OAS30Validator
 from poolboy import Poolboy
 from poolboy_templating import check_condition, recursive_process_template_strings
 
@@ -167,11 +165,11 @@ class ResourceProvider:
             if provider.is_match_for_template(template):
                 provider_matches.append(provider)
         if len(provider_matches) == 0:
-            raise kopf.TemporaryError(f"Unable to match template to ResourceProvider", delay=60)
+            raise kopf.TemporaryError("Unable to match template to ResourceProvider", delay=60)
         elif len(provider_matches) == 1:
             return provider_matches[0]
         else:
-            raise kopf.TemporaryError(f"Resource template matches multiple ResourceProviders", delay=600)
+            raise kopf.TemporaryError("Resource template matches multiple ResourceProviders", delay=600)
 
     @classmethod
     async def get(cls, name: str) -> ResourceProviderT:
@@ -737,9 +735,9 @@ class ResourceProvider:
             if 'namespace' in resource_reference:
                 resource_definition['metadata']['namespace'] = resource_reference['namespace']
             if resource_definition['apiVersion'] != resource_reference['apiVersion']:
-                raise kopf.TemporaryError(f"Unable to change apiVersion for resource!", delay=600)
+                raise kopf.TemporaryError("Unable to change apiVersion for resource!", delay=600)
             if resource_definition['kind'] != resource_reference['kind']:
-                raise kopf.TemporaryError(f"Unable to change kind for resource!", delay=600)
+                raise kopf.TemporaryError("Unable to change kind for resource!", delay=600)
 
         if 'annotations' not in resource_definition['metadata']:
             resource_definition['metadata']['annotations'] = {}
@@ -754,7 +752,13 @@ class ResourceProvider:
         })
 
         if resource_claim:
+            # TODO: The following annotations are kept for backward
+            # compatibility and will be removed in the future.
             resource_definition['metadata']['annotations'].update({
+                f"{Poolboy.operator_domain}/resource-claim-name": resource_claim.name,
+                f"{Poolboy.operator_domain}/resource-claim-namespace": resource_claim.namespace,
+            })
+            resource_definition['metadata'].setdefault('labels', {}).update({
                 f"{Poolboy.operator_domain}/resource-claim-name": resource_claim.name,
                 f"{Poolboy.operator_domain}/resource-claim-namespace": resource_claim.namespace,
             })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 inflection==0.5.1
-Jinja2==3.1.5
+Jinja2==3.1.6
 jmespath-community==1.1.2
 jsonpointer==2.2
 jsonschema==3.2.0


### PR DESCRIPTION
- Add workflow_dispatch support for manual version publishing
- Upgrade actions/checkout to v4
- Replace Buildah with Docker Buildx for better compatibility
- Add Helm chart linting and validation
- Update azure/setup-helm to v4
- Migrate kopf base image from quay.io/redhat-cop to quay.io/rhpds/python-kopf-s2i:v1.38
- Add backward compatibility comment for resource annotations
- Update .gitignore to exclude .venv directory