### PR TITLE
Add template variables

### DIFF
--- a/build-template.yaml
+++ b/build-template.yaml
@@ -44,35 +44,4 @@ objects:
       dockerStrategy:
         dockerfilePath: Containerfile
     triggers: []
-
-- apiVersion: image.openshift.io/v1
-  kind: ImageStream
-  metadata:
-    name: ${NAME}-admin
-  spec:
-    lookupPolicy:
-      local: false
-
-- apiVersion: v1
-  kind: BuildConfig
-  metadata:
-    name: ${NAME}-admin
-  spec:
-    output:
-      to:
-        kind: ImageStreamTag
-        name: ${NAME}-admin:latest
-    postCommit: {}
-    resources: {}
-    runPolicy: Serial
-    source:
-      contextDir: admin
-      git:
-        uri: ${GIT_REPO}
-        ref: ${GIT_REF}
-    strategy:
-      type: Docker
-      dockerStrategy:
-        forcePull: true
-    triggers: []
 ...

--- a/operator/poolboy_templating.py
+++ b/operator/poolboy_templating.py
@@ -218,6 +218,18 @@ def jinja2process(template, omit=None, template_style='jinja2', variables={}, te
         return template_out
 
 def recursive_process_template_strings(template, template_style='jinja2', variables={}, template_variables={}):
+    """Take a template and recursively process template strings within it.
+    The template may be any type.
+    If it is a dictionary or list then all values will be recursively procesed.
+    Strings will be handled as templates and values replaced by output.
+    If a template string ends in a bool, float, int, or object filter then
+    output will be converted from string to the corresponding type.
+
+    Keyword arguments:
+    template_style -- Style of templates used. Currently only "jinja2" is supported
+    variables -- simple key/value pair variables
+    template_variables -- variables which may contain template strings and should only come from trusted sources
+    """
     omit = '__omit_place_holder__' + ''.join(random.choices('abcdef0123456789', k=40))
     return __recursive_strip_omit(
         __recursive_process_template_strings(

--- a/operator/poolboy_templating.py
+++ b/operator/poolboy_templating.py
@@ -225,6 +225,9 @@ def recursive_process_template_strings(template, template_style='jinja2', variab
     If a template string ends in a bool, float, int, or object filter then
     output will be converted from string to the corresponding type.
 
+    This method is used in various places including generating status summary,
+    validating parameters, checking heath/readiness, and generating resource definitions.
+
     Keyword arguments:
     template_style -- Style of templates used. Currently only "jinja2" is supported
     variables -- simple key/value pair variables

--- a/operator/poolboy_templating.py
+++ b/operator/poolboy_templating.py
@@ -8,8 +8,10 @@ import random
 import re
 
 from datetime import datetime, timedelta, timezone
-from distutils.util import strtobool
 from strgen import StringGenerator
+from str2bool import str2bool
+
+MAX_RECURSION_DEPTH = 100
 
 class TimeStamp(object):
     def __init__(self, set_datetime=None):
@@ -105,13 +107,13 @@ jinja2envs = {
         undefined = jinja2.ChainableUndefined,
     ),
 }
-jinja2envs['jinja2'].filters['bool'] = lambda x: bool(strtobool(x)) if isinstance(x, str) else bool(x)
+jinja2envs['jinja2'].filters['bool'] = lambda x: bool(str2bool(x)) if isinstance(x, str) else bool(x)
 jinja2envs['jinja2'].filters['json_query'] = lambda x, query: jmespath.search(query, x)
 jinja2envs['jinja2'].filters['merge_list_of_dicts'] = lambda a: functools.reduce(lambda d1, d2: {**(d1 or {}), **(d2 or {})}, a) if a else {}
 jinja2envs['jinja2'].filters['object'] = lambda x: json.dumps(x)
-jinja2envs['jinja2'].filters['parse_time_interval'] = lambda x: timedelta(seconds=pytimeparse.parse(x))
+jinja2envs['jinja2'].filters['parse_time_interval'] = lambda x: timedelta(seconds=pytimeparse.parse(str(x)))
 jinja2envs['jinja2'].filters['strgen'] = lambda x: StringGenerator(x).render()
-jinja2envs['jinja2'].filters['to_datetime'] = lambda s, f='%Y-%m-%d %H:%M:%S': datetime.strptime(s, f)
+jinja2envs['jinja2'].filters['to_datetime'] = lambda s, f='%Y-%m-%d %H:%M:%S': datetime.strptime(str(s), f)
 jinja2envs['jinja2'].filters['to_json'] = lambda x: json.dumps(x)
 
 # Regex to detect if it looks like this value should be rendered as a raw type
@@ -144,18 +146,19 @@ jinja2envs['jinja2'].filters['to_json'] = lambda x: json.dumps(x)
 #       name: alice
 type_filter_match_re = re.compile(r'^{{(?!.*{{).*\| *(bool|float|int|object) *}}$')
 
-def check_condition(condition, template_style='jinja2', variables={}):
+def check_condition(condition, template_style='jinja2', variables={}, template_variables={}):
     return jinja2process(
         template="{{ (" + condition + ") | bool}}",
         template_style=template_style,
-        variables=variables
+        variables=variables,
+        template_variables=template_variables,
     )
 
 def j2now(utc=False, fmt=None):
     dt = datetime.now(timezone.utc if utc else None)
     return dt.strftime(fmt) if fmt else dt
 
-def jinja2process(template, omit=None, template_style='jinja2', variables={}):
+def jinja2process(template, omit=None, template_style='jinja2', variables={}, template_variables={}):
     variables = copy.copy(variables)
     variables['datetime'] = datetime
     variables['now'] = j2now
@@ -163,8 +166,38 @@ def jinja2process(template, omit=None, template_style='jinja2', variables={}):
     variables['timedelta'] = timedelta
     variables['timezone'] = timezone
     variables['timestamp'] = TimeStamp()
+    variables['__recursion_depth__'] = 0
     jinja2env = jinja2envs.get(template_style)
     j2template = jinja2env.from_string(template)
+
+    class TemplateVariable(object):
+        '''Variable may contain template string referencing other variables.'''
+        def __init__(self, value):
+            self.j2template = jinja2env.from_string(value)
+
+        def __bool__(self):
+            return bool(self.__str__())
+
+        def __float__(self):
+            return float(self.__str__())
+
+        def __int__(self):
+            return int(self.__str__())
+
+        def __repr__(self):
+            return self.__str__()
+
+        def __str__(self):
+            if variables['__recursion_depth__'] > MAX_RECURSION_DEPTH:
+                raise RuntimeError("Template variable exceeded max recursion")
+            variables['__recursion_depth__'] += 1
+            ret = self.j2template.render(variables)
+            variables['__recursion_depth__'] -= 1
+            return ret
+
+    for name, value in template_variables.items():
+        variables[name] = TemplateVariable(value) if isinstance(value, str) else value
+
     template_out = j2template.render(variables)
 
     type_filter_match = type_filter_match_re.match(template)
@@ -172,7 +205,7 @@ def jinja2process(template, omit=None, template_style='jinja2', variables={}):
         type_filter = type_filter_match.group(1)
         try:
             if type_filter == 'bool':
-                return bool(strtobool(template_out))
+                return bool(str2bool(template_out))
             elif type_filter == 'float':
                 return float(template_out)
             elif type_filter == 'int':
@@ -184,7 +217,7 @@ def jinja2process(template, omit=None, template_style='jinja2', variables={}):
     else:
         return template_out
 
-def recursive_process_template_strings(template, template_style='jinja2', variables={}):
+def recursive_process_template_strings(template, template_style='jinja2', variables={}, template_variables={}):
     omit = '__omit_place_holder__' + ''.join(random.choices('abcdef0123456789', k=40))
     return __recursive_strip_omit(
         __recursive_process_template_strings(
@@ -192,23 +225,24 @@ def recursive_process_template_strings(template, template_style='jinja2', variab
             template = template,
             template_style = template_style,
             variables = variables,
+            template_variables = template_variables,
         ),
         omit = omit,
     )
 
-def __recursive_process_template_strings(template, omit, template_style, variables):
+def __recursive_process_template_strings(template, omit, template_style, variables, template_variables):
     if isinstance(template, dict):
         return {
-            key: __recursive_process_template_strings(val, omit=omit, template_style=template_style, variables=variables)
+            key: __recursive_process_template_strings(val, omit=omit, template_style=template_style, variables=variables, template_variables=template_variables)
             for key, val in template.items()
         }
     elif isinstance(template, list):
         return [
-            __recursive_process_template_strings(item, omit=omit, template_style=template_style, variables=variables)
+            __recursive_process_template_strings(item, omit=omit, template_style=template_style, variables=variables, template_variables=template_variables)
             for item in template
         ]
     elif isinstance(template, str):
-        return jinja2process(template, omit=omit, template_style=template_style, variables=variables)
+        return jinja2process(template, omit=omit, template_style=template_style, variables=variables, template_variables=template_variables)
     else:
         return template
 

--- a/operator/resourcehandle.py
+++ b/operator/resourcehandle.py
@@ -299,13 +299,9 @@ class ResourceHandle(KopfObject):
             lifespan_relative_maximum = resource_provider.lifespan_relative_maximum
             lifespan_relative_maximum_timedelta = resource_provider.get_lifespan_maximum_timedelta(resource_claim)
         else:
-            vars_ = {}
-
             resource_providers = await resource_claim.get_resource_providers(resource_claim_resources)
             for i, claim_resource in enumerate(resource_claim_resources):
                 provider = resource_providers[i]
-                vars_.update(provider.vars)
-
                 provider_lifespan_default_timedelta = provider.get_lifespan_default_timedelta(resource_claim)
                 if provider_lifespan_default_timedelta:
                     if not lifespan_default_timedelta \
@@ -334,7 +330,6 @@ class ResourceHandle(KopfObject):
                 resources.append(resources_item)
 
             definition['spec']['resources'] = resources
-            definition['spec']['vars'] = vars_
 
         lifespan_end_datetime = None
         lifespan_start_datetime = datetime.now(timezone.utc)
@@ -744,10 +739,10 @@ class ResourceHandle(KopfObject):
         value = recursive_process_template_strings(
             template = value,
             variables = {
-                **self.vars,
                 "resource_claim": resource_claim,
                 "resource_handle": self,
             },
+            template_variables = self.vars,
         )
 
         return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ python-string-utils==1.0.0
 pytimeparse==1.1.8
 PyYAML==6.0.1
 requests==2.32.0
+str2bool==1.1
 StringGenerator==0.4.4
 urllib3==1.26.19

--- a/test/unittest-poolboy_templating.py
+++ b/test/unittest-poolboy_templating.py
@@ -457,7 +457,7 @@ class TestJsonPatch(unittest.TestCase):
             "A"
         )
 
-    def test_32(self):
+    def test_33(self):
         template = "{{ a | int }}"
         template_variables = {
             "a": "{{ b }}",
@@ -469,6 +469,16 @@ class TestJsonPatch(unittest.TestCase):
             ),
             2
         )
+
+    def test_34(self):
+        template = "{{ a }}"
+        template_variables = {
+            "a": "{{ a }}",
+        }
+        with self.assertRaises(Exception):
+            recursive_process_template_strings(
+                template, 'jinja2', template_variables=template_variables
+            ),
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unittest-poolboy_templating.py
+++ b/test/unittest-poolboy_templating.py
@@ -9,9 +9,9 @@ from poolboy_templating import recursive_process_template_strings, seconds_to_in
 class TestJsonPatch(unittest.TestCase):
     def test_00(self):
         template = {}
-        template_vars = {}
+        variables = {}
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             {}
         )
 
@@ -24,9 +24,9 @@ class TestJsonPatch(unittest.TestCase):
                 "e": ["a", "b", "c"]
             }
         }
-        template_vars = {}
+        variables = {}
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             template
         )
 
@@ -34,11 +34,11 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "a": "{{ foo }}",
         }
-        template_vars = {
+        variables = {
             "foo": "bar"
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             {
                 "a": "bar"
             }
@@ -48,11 +48,11 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "a": ["{{ foo }}"],
         }
-        template_vars = {
+        variables = {
             "foo": "bar"
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             {
                 "a": ["bar"]
             }
@@ -62,11 +62,11 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "a": "{{ foo }}"
         }
-        template_vars = {
+        variables = {
             "foo": True
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             {
                 "a": "True"
             }
@@ -76,11 +76,11 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "a": "{{ foo | bool }}"
         }
-        template_vars = {
+        variables = {
             "foo": True
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             {
                 "a": True
             }
@@ -90,12 +90,12 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "a": "{{ numerator / denominator }}"
         }
-        template_vars = {
+        variables = {
             "numerator": 1,
             "denominator": 2,
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             {
                 "a": "0.5"
             }
@@ -105,12 +105,12 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "a": "{{ (numerator / denominator) | float }}"
         }
-        template_vars = {
+        variables = {
             "numerator": 1,
             "denominator": 2,
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             {
                 "a": 0.5
             }
@@ -120,11 +120,11 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "a": "{{ n }}"
         }
-        template_vars = {
+        variables = {
             "n": 21,
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             {
                 "a": "21"
             }
@@ -134,11 +134,11 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "a": "{{ n | int }}"
         }
-        template_vars = {
+        variables = {
             "n": 21
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             {
                 "a": 21
             }
@@ -148,13 +148,13 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "user": "{{ user }}"
         }
-        template_vars = {
+        variables = {
             "user": {
                 "name": "alice"
             }
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             {
                 "user": "{'name': 'alice'}"
             }
@@ -164,13 +164,13 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "user": "{{ user | object }}"
         }
-        template_vars = {
+        variables = {
             "user": {
                 "name": "alice"
             }
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars),
+            recursive_process_template_strings(template, 'jinja2', variables),
             {
                 "user": {
                     "name": "alice"
@@ -182,48 +182,48 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "now": "{{ now() }}"
         }
-        template_vars = {}
-        template_out = recursive_process_template_strings(template, 'jinja2', template_vars)
+        variables = {}
+        template_out = recursive_process_template_strings(template, 'jinja2', variables)
         self.assertRegex(template_out['now'], r'^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d+$')
 
     def test_13(self):
         template = {
             "now": "{{ now(True, '%FT%TZ') }}"
         }
-        template_vars = {}
-        template_out = recursive_process_template_strings(template, 'jinja2', template_vars)
+        variables = {}
+        template_out = recursive_process_template_strings(template, 'jinja2', variables)
         self.assertRegex(template_out['now'], r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
 
     def test_14(self):
         template = {
             "ts": "{{ (now() + timedelta(hours=3)).strftime('%FT%TZ') }}"
         }
-        template_vars = {}
-        template_out = recursive_process_template_strings(template, 'jinja2', template_vars)
+        variables = {}
+        template_out = recursive_process_template_strings(template, 'jinja2', variables)
         self.assertRegex(template_out['ts'], r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
 
     def test_15(self):
         template = {
             "ts": "{{ (now() + timedelta(hours=3)).strftime('%FT%TZ') }}"
         }
-        template_vars = {}
-        template_out = recursive_process_template_strings(template, 'jinja2', template_vars)
+        variables = {}
+        template_out = recursive_process_template_strings(template, 'jinja2', variables)
         self.assertRegex(template_out['ts'], r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
 
     def test_16(self):
         template = {
             "ts": "{{ (datetime.now(timezone.utc) + timedelta(hours=3)).strftime('%FT%TZ') }}"
         }
-        template_vars = {}
-        template_out = recursive_process_template_strings(template, 'jinja2', template_vars)
+        variables = {}
+        template_out = recursive_process_template_strings(template, 'jinja2', variables)
         self.assertRegex(template_out['ts'], r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
 
     def test_17(self):
         template = {
             "ts": "{{ (datetime.now(timezone.utc) + '3h' | parse_time_interval).strftime('%FT%TZ') }}"
         }
-        template_vars = {}
-        template_out = recursive_process_template_strings(template, 'jinja2', template_vars)
+        variables = {}
+        template_out = recursive_process_template_strings(template, 'jinja2', variables)
         self.assertRegex(template_out['ts'], r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
 
     def test_18(self):
@@ -231,8 +231,8 @@ class TestJsonPatch(unittest.TestCase):
             "ts1": "{{ timestamp.add('3h') }}",
             "ts2": "{{ (datetime.now(timezone.utc) + timedelta(hours=3)).strftime('%FT%TZ') }}"
         }
-        template_vars = {}
-        template_out = recursive_process_template_strings(template, 'jinja2', template_vars)
+        variables = {}
+        template_out = recursive_process_template_strings(template, 'jinja2', variables)
         self.assertRegex(template_out['ts1'], r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
         self.assertEqual(template_out['ts1'], template_out['ts2'])
 
@@ -240,24 +240,24 @@ class TestJsonPatch(unittest.TestCase):
         template = {
             "ts": "{{ timestamp('1970-01-01T01:02:03Z').add('3h') }}",
         }
-        template_vars = {}
-        template_out = recursive_process_template_strings(template, 'jinja2', template_vars)
+        variables = {}
+        template_out = recursive_process_template_strings(template, 'jinja2', variables)
         self.assertEqual(template_out['ts'], '1970-01-01T04:02:03Z')
 
     def test_20(self):
         template = "{{ user | json_query('name') }}"
-        template_vars = {
+        variables = {
             "user": {
                 "name": "alice"
             }
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), "alice"
+            recursive_process_template_strings(template, 'jinja2', variables), "alice"
         )
 
     def test_21(self):
         template = "{{ users | json_query('[].name') | object }}"
-        template_vars = {
+        variables = {
             "users": [
                 {
                     "name": "alice",
@@ -269,7 +269,7 @@ class TestJsonPatch(unittest.TestCase):
             ]
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), ["alice", "bob"]
+            recursive_process_template_strings(template, 'jinja2', variables), ["alice", "bob"]
         )
 
     # Test complicated case used to determine desired state in babylon governor
@@ -288,7 +288,7 @@ class TestJsonPatch(unittest.TestCase):
         stopped
         {%- endif -%}
         """
-        template_vars = {
+        variables = {
             "resource_states": [
                 {
                     "status": {
@@ -334,23 +334,23 @@ class TestJsonPatch(unittest.TestCase):
         }
 
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), "stopped"
+            recursive_process_template_strings(template, 'jinja2', variables), "stopped"
         )
 
-        template_vars['resource_templates'][0]['spec']['vars']['action_schedule']['stop'] = '2099-12-31T23:59:59Z'
+        variables['resource_templates'][0]['spec']['vars']['action_schedule']['stop'] = '2099-12-31T23:59:59Z'
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), "started"
+            recursive_process_template_strings(template, 'jinja2', variables), "started"
         )
 
-        template_vars['resource_templates'][0]['spec']['vars']['action_schedule']['stop'] = '2022-01-01T00:00:00Z'
-        del template_vars['resource_states'][1]['status']['towerJobs']['provision']['completeTimestamp']
+        variables['resource_templates'][0]['spec']['vars']['action_schedule']['stop'] = '2022-01-01T00:00:00Z'
+        del variables['resource_states'][1]['status']['towerJobs']['provision']['completeTimestamp']
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), "started"
+            recursive_process_template_strings(template, 'jinja2', variables), "started"
         )
 
-        del template_vars['resource_states'][1]['status']['towerJobs']['provision']
+        del variables['resource_states'][1]['status']['towerJobs']['provision']
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), "started"
+            recursive_process_template_strings(template, 'jinja2', variables), "started"
         )
 
     def test_23(self):
@@ -364,18 +364,18 @@ class TestJsonPatch(unittest.TestCase):
             "a": "A",
             "b": "{{ omit }}",
         }
-        template_vars = {}
+        variables = {}
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), {"a": "A"}
+            recursive_process_template_strings(template, 'jinja2', variables), {"a": "A"}
         )
 
     def test_25(self):
         template = [
             "a", "{{ omit }}", "b"
         ]
-        template_vars = {}
+        variables = {}
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), ["a", "b"]
+            recursive_process_template_strings(template, 'jinja2', variables), ["a", "b"]
         )
 
     def test_26(self):
@@ -383,56 +383,91 @@ class TestJsonPatch(unittest.TestCase):
             "a": "{{ a | default(omit) }}",
             "b": "{{ b | default(omit) }}",
         }
-        template_vars = {
+        variables = {
             "a": "A",
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), {"a": "A"}
+            recursive_process_template_strings(template, 'jinja2', variables), {"a": "A"}
         )
 
     def test_27(self):
         template = "{{ l | json_query('from_items(zip([].keys(@)[], [].values(@)[]))') | object }}"
-        template_vars = {
+        variables = {
             "l": [{"a": "A", "b": "X"}, {"b": "B", "c": "C"}, {"d": "D"}]
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), {"a": "A", "b": "B", "c": "C", "d": "D"}
+            recursive_process_template_strings(template, 'jinja2', variables), {"a": "A", "b": "B", "c": "C", "d": "D"}
         )
 
     def test_28(self):
         template = "{{ l | merge_list_of_dicts | object }}"
-        template_vars = {
+        variables = {
             "l": [{"a": "A", "b": "X"}, {"b": "B", "c": "C"}, {"d": "D"}]
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), {"a": "A", "b": "B", "c": "C", "d": "D"}
+            recursive_process_template_strings(template, 'jinja2', variables), {"a": "A", "b": "B", "c": "C", "d": "D"}
         )
 
     def test_29(self):
         template = "{{ l | merge_list_of_dicts | object }}"
-        template_vars = {
+        variables = {
             "l": [{"a": "A", "b": "X"}, None, {"b": "B", "c": "C"}, {}, {"d": "D"}]
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), {"a": "A", "b": "B", "c": "C", "d": "D"}
+            recursive_process_template_strings(template, 'jinja2', variables), {"a": "A", "b": "B", "c": "C", "d": "D"}
         )
 
     def test_30(self):
         template = "{{ l | merge_list_of_dicts | object }}"
-        template_vars = {
+        variables = {
             "l": []
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), {}
+            recursive_process_template_strings(template, 'jinja2', variables), {}
         )
 
     def test_31(self):
         template = "{{ l | merge_list_of_dicts | object }}"
-        template_vars = {
+        variables = {
             "l": [{"a": "A"}]
         }
         self.assertEqual(
-            recursive_process_template_strings(template, 'jinja2', template_vars), {"a": "A"}
+            recursive_process_template_strings(template, 'jinja2', variables), {"a": "A"}
+        )
+
+    def test_31(self):
+        template = "{{ l | merge_list_of_dicts | object }}"
+        variables = {
+            "l": [{"a": "A"}]
+        }
+        self.assertEqual(
+            recursive_process_template_strings(template, 'jinja2', variables), {"a": "A"}
+        )
+
+    def test_32(self):
+        template = "{{ a }}"
+        template_variables = {
+            "a": "{{ b }}",
+            "b": "A",
+        }
+        self.assertEqual(
+            recursive_process_template_strings(
+                template, 'jinja2', template_variables=template_variables
+            ),
+            "A"
+        )
+
+    def test_32(self):
+        template = "{{ a | int }}"
+        template_variables = {
+            "a": "{{ b }}",
+            "b": 2,
+        }
+        self.assertEqual(
+            recursive_process_template_strings(
+                template, 'jinja2', template_variables=template_variables
+            ),
+            2
         )
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Add support for template variables in ResourceProvider such that they evaluate recursively similar to Ansible variables.
- Remove copying of ResourceProvider variables to ResourceHandles
- Switch to str2bool to handle removal of distutils strtobool
- Clean up old references to admin in build template
- Update to python-kopf-s2i new quay repo